### PR TITLE
Fixed Cross-site Scripting (XSS) Vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "homepage": "https://github.com/hinesboy/mavonEditor#readme",
   "dependencies": {
     "highlight.js": "^9.11.0",
-    "highlight.js-async-webpack": "^1.0.4"
+    "highlight.js-async-webpack": "^1.0.4",
+    "xss": "^1.0.6"
   },
   "devDependencies": {
     "auto-textarea": "^1.4.0",

--- a/src/mavon-editor.vue
+++ b/src/mavon-editor.vue
@@ -93,6 +93,7 @@ import {autoTextarea} from 'auto-textarea'
 import {keydownListen} from './lib/core/keydown-listen.js'
 import hljsCss from './lib/core/hljs/lang.hljs.css.js'
 import hljsLangs from './lib/core/hljs/lang.hljs.js'
+var xss = require('xss');
 import {
     fullscreenchange,
    /* windowResize, */
@@ -659,6 +660,9 @@ export default {
             this.iRender();
         },
         value: function (val, oldVal) {
+            // Escaping all XSS characters
+            val = xss(val);
+
             if (val !== this.d_value) {
                 this.d_value = val
             }

--- a/src/mavon-editor.vue
+++ b/src/mavon-editor.vue
@@ -93,7 +93,7 @@ import {autoTextarea} from 'auto-textarea'
 import {keydownListen} from './lib/core/keydown-listen.js'
 import hljsCss from './lib/core/hljs/lang.hljs.css.js'
 import hljsLangs from './lib/core/hljs/lang.hljs.js'
-var xss = require('xss');
+const xss = require('xss');
 import {
     fullscreenchange,
    /* windowResize, */


### PR DESCRIPTION
**Bug fix:**
Sanitized the input value on the textarea of the `vNoteEdit` panel using the [xss](https://www.npmjs.com/package/xss) module, so that it escapes all the inputs resulting in an XSS. 

The XSS mitigation is implemented inside the `watch: { value: function (val, oldVal) }`, which passes the `val` variable through the xss() and return the escaped output to the `d_value` variable. 

**XSS Vulnerability:**

![before](https://user-images.githubusercontent.com/16708391/75613518-ac0af080-5b54-11ea-8e4f-cc9f82b6913b.PNG)

**After fix:**

![after](https://user-images.githubusercontent.com/16708391/75613546-f1c7b900-5b54-11ea-90fe-25f16c5b63a1.PNG)

**Files changed:**
- package.json
- mavon-editor.vue
